### PR TITLE
Fix mapIsolationLevel error (#4)

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -10,7 +10,7 @@ var Transaction = require('loopback-connector').Transaction;
 
 module.exports = mixinTransaction;
 
-mapIsolationLevel = function(isolationLevelString) {
+var mapIsolationLevel = function(isolationLevelString) {
   switch (isolationLevelString) {
     case Transaction.READ_UNCOMMITTED:
       ret = 1;


### PR DESCRIPTION
Missing "var" in front of variable declaration. This is causing `npm
test` to fail.

Backport of #4 

cc @bajtos @qpresley @strongloop/fa-db-connectors 
