### PR TITLE
Add missing functions as part of refactor - DB2iSeries

### DIFF
--- a/lib/db2i.js
+++ b/lib/db2i.js
@@ -367,3 +367,4 @@ DB2.prototype.destroyAll = function(model, where, options, callback) {
 };
 
 require('./transaction')(DB2);
+require('./migration')(DB2);

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -1,0 +1,113 @@
+// Copyright IBM Corp. 2016. All Rights Reserved.
+// Node module: loopback-connector-DB2iSeries
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+'use strict';
+
+var g = require('./globalize');
+
+/*!
+ * DB2iSeries connector for LoopBack
+ */
+var async = require('async');
+
+module.exports = function(DB2iSeries) {
+  DB2iSeries.prototype.getAddModifyColumns = function(model, fields) {
+    process.nextTick(function() {
+      throw new Error(g.f('{{getAddModifyColumns()}} is ' +
+      'not currently supported.'));
+    });
+  };
+
+  DB2iSeries.prototype.getDropColumns = function(model, fields) {
+    process.nextTick(function() {
+      throw new Error(g.f('{{getDropColumns()}} is not currently supported.'));
+    });
+  };
+
+  DB2iSeries.prototype.getColumnsToDrop = function(model, fields) {
+    process.nextTick(function() {
+      throw new Error(g.f('{{getColumnsToDrop()}} is not ' +
+      'currently supported.'));
+    });
+  };
+
+  DB2iSeries.prototype.searchForPropertyInActual =
+  function(model, propName, actualFields) {
+    process.nextTick(function() {
+      throw new Error(g.f('{{searchForPropertyInActual()}} is ' +
+      'not currently supported.'));
+    });
+  };
+
+  DB2iSeries.prototype.addPropertyToActual = function(model, propName) {
+    process.nextTick(function() {
+      throw new Error(g.f('{{addPropertyToActual()}} is ' +
+      'not currently supported.'));
+    });
+  };
+
+  DB2iSeries.prototype.columnDataType = function(model, property) {
+    process.nextTick(function() {
+      throw new Error(g.f('{{columnDataType()}} is not currently supported.'));
+    });
+  };
+
+  DB2iSeries.prototype.buildColumnType = function(property) {
+    process.nextTick(function() {
+      throw new Error(g.f('{{buildColumnType()}} is not currently supported.'));
+    });
+  };
+
+  DB2iSeries.prototype.propertyHasNotBeenDeleted = function(model, propName) {
+    process.nextTick(function() {
+      throw new Error(g.f('{{propertyHasNotBeenDeleted()}} is ' +
+      'not currently supported.'));
+    });
+  };
+
+  DB2iSeries.prototype.applySqlChanges =
+  function(model, pendingChanges, cb) {
+    process.nextTick(function() {
+      return cb(Error(g.f('{{applySqlChanges()}} is not ' +
+      'currently supported.')));
+    });
+  };
+
+  DB2iSeries.prototype.showFields = function(model, cb) {
+    process.nextTick(function() {
+      return cb(Error(g.f('{{showFields()}} is not currently supported.')));
+    });
+  };
+
+  DB2iSeries.prototype.showIndexes = function(model, cb) {
+    process.nextTick(function() {
+      return cb(Error(g.f('{{showIndexes()}} is not currently supported.')));
+    });
+  };
+
+  DB2iSeries.prototype.autoupdate = function(models, cb) {
+    process.nextTick(function() {
+      return cb(Error(g.f('{{autoupdate()}} is not currently supported.')));
+    });
+  };
+
+  DB2iSeries.prototype.isActual = function(models, cb) {
+    process.nextTick(function() {
+      return cb(Error(g.f('{{isActual()}} is not currently supported.')));
+    });
+  };
+
+  DB2iSeries.prototype.alterTable = function(model, fields, indexes, cb) {
+    process.nextTick(function() {
+      return cb(Error(g.f('{{alterTable()}} is not currently supported.')));
+    });
+  };
+
+  DB2iSeries.prototype.getTableStatus = function(model, cb) {
+    process.nextTick(function() {
+      return cb(Error(g.f('{{getTableStatus()}} is not currently supported.')));
+    });
+  };
+};

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   "dependencies": {
     "async": "^1.5.0",
     "debug": "^2.2.0",
-    "loopback-connector": "^2.3.0",
-    "loopback-ibmdb": "^1.0.0",
+    "loopback-connector": "^3.0.0",
+    "loopback-ibmdb": "^2.0.0",
     "strong-globalize": "^2.8.2"
   },
   "devDependencies": {


### PR DESCRIPTION
@qpresley PTAL

For db2iseries I had to add the whole `migration.js` file to accommodate these functions. These are the functions that were refactored as a whole in the loopback base connector and ibmdb connector, and it will be overridden by the new definition **if** they are called for this connector.